### PR TITLE
Use Pointer for COM types

### DIFF
--- a/lib/src/projection/typeprinter.dart
+++ b/lib/src/projection/typeprinter.dart
@@ -282,6 +282,8 @@ class ${type.className} extends $interfaceWithoutNamespace {
 
 // THIS FILE IS GENERATED AUTOMATICALLY AND SHOULD NOT BE EDITED DIRECTLY.
 
+// ignore_for_file: unused_local_variable
+
 @TestOn('windows')
 
 import 'dart:ffi';

--- a/lib/src/projection/typeprojector.dart
+++ b/lib/src/projection/typeprojector.dart
@@ -89,6 +89,12 @@ class TypeProjector {
               // Win32 meaning, which is more like "undefined type". We can
               // model that with a generic Pointer in Dart.
               return 'Pointer';
+            } else if (typeArgs.first.type != null &&
+                typeArgs.first.type!.interfaces.isNotEmpty &&
+                typeArgs.first.type!.interfaces.first.typeName ==
+                    'Windows.Win32.Com.IUnknown') {
+              // COM type
+              return 'Pointer<Pointer>';
             } else {
               // If it's a double- (or triple-) dereferenced pointer, then
               // create a new typeIdentifier, based on the first typeArgs entry
@@ -108,6 +114,14 @@ class TypeProjector {
         return 'Pointer';
 
       default:
+    }
+
+    // COM type
+    if (typeIdentifier.type != null &&
+        typeIdentifier.type!.interfaces.isNotEmpty &&
+        typeIdentifier.type!.interfaces.first.typeName ==
+            'Windows.Win32.Com.IUnknown') {
+      return 'Pointer';
     }
 
     // If it's a Win32 type, we know how to get the type
@@ -205,6 +219,12 @@ class TypeProjector {
               // Win32/C meaning, which is more like "undefined type". We can
               // model that with a generic Pointer in Dart.
               return 'Pointer';
+            } else if (typeArgs.first.type != null &&
+                typeArgs.first.type!.interfaces.isNotEmpty &&
+                typeArgs.first.type!.interfaces.first.typeName ==
+                    'Windows.Win32.Com.IUnknown') {
+              // COM type
+              return 'Pointer<Pointer>';
             } else {
               // If it's a double- (or triple-) dereferenced pointer, then
               // create a new typeIdentifier, based on the first typeArgs entry
@@ -227,6 +247,15 @@ class TypeProjector {
         return 'IntPtr';
       default:
     }
+
+    // COM type
+    if (typeIdentifier.type != null &&
+        typeIdentifier.type!.interfaces.isNotEmpty &&
+        typeIdentifier.type!.interfaces.first.typeName ==
+            'Windows.Win32.Com.IUnknown') {
+      return 'Pointer';
+    }
+
     // If it's a Win32 type, we know how to get the type
     if (typeIdentifier.type != null &&
         typeIdentifier.type!.typeName.startsWith('Windows.Win32')) {

--- a/lib/src/projection/win32types.dart
+++ b/lib/src/projection/win32types.dart
@@ -319,6 +319,7 @@ const win32TypeMap = <String, String>{
   'ACTIVATEOPTIONS': 'Uint32',
   'CDCONTROLSTATEF': 'Uint32',
   'ConsoleMode': 'Uint32',
+  'CORRECTIVE_ACTION': 'Uint32',
   'DESKTOP_SLIDESHOW_DIRECTION': 'Uint32',
   'DESKTOP_SLIDESHOW_OPTIONS': 'Uint32',
   'DESKTOP_SLIDESHOW_STATE': 'Uint32',

--- a/test/com_test.dart
+++ b/test/com_test.dart
@@ -266,5 +266,17 @@ void main() {
       expect(projector.nativeType, equals('Uint32'));
       expect(projector.dartType, equals('int'));
     });
+
+    test('Unidentified COM interfaces should be represented as Pointers', () {
+      final iSpellChecker = scope['Windows.Win32.Intl.ISpellCheckerFactory']!;
+      final createSpellChecker =
+          iSpellChecker.findMethod('CreateSpellChecker')!;
+      final type = createSpellChecker
+          .parameters.last.typeIdentifier; // ISpellChecker **value
+      final typeProjection = TypeProjector(type);
+
+      expect(typeProjection.nativeType, equals('Pointer<Pointer>'));
+      expect(typeProjection.dartType, equals('Pointer<Pointer>'));
+    });
   });
 }


### PR DESCRIPTION
When generating COM API with your [Win32](https://github.com/timsneath/win32) package, types are referencing other classes, which aren't native types, like so: 
```dart
typedef _CreateSpellChecker_Native = Int32 Function(
  Pointer obj,
  Pointer<Utf16> languageTag, 
  Pointer<ISpellChecker> value
);
typedef _Invoke_Native = Int32 Function(
  Pointer obj,
  ISpellChecker sender
);
```

This commit changes this result into this
```dart
typedef _CreateSpellChecker_Native = Int32 Function(
  Pointer obj,
  Pointer<Utf16> languageTag, 
  Pointer<Pointer> value
);
typedef _Invoke_Native = Int32 Function(
  Pointer obj,
  Pointer sender
);
```