### PR TITLE
Use Maps for faster lookups of TypeDefs by name/token and isDelegate

### DIFF
--- a/lib/src/typedef.dart
+++ b/lib/src/typedef.dart
@@ -375,6 +375,9 @@ class TypeDef extends TokenObject
   /// Returns true if the type is a delegate.
   bool get isDelegate => parent?.name == 'System.MulticastDelegate';
 
+  /// Returns true if the type is an enumeration.
+  bool get isEnum => parent?.name == 'System.Enum';
+
   /// Returns true if the type is a union.
   ///
   /// A union is a struct where every field begins at the zeroth offset; it is


### PR DESCRIPTION
@timsneath these functions are called a lot on the same scope during regeneration in `package:win32` and enumerating the lists seems to take considerable time (more than I would ever have imagined). Testing on my desktop (an aging Core i5-4430) running from the command line with a clean checkout if the repo each time shows a significant reduction in total run time:

```
Before:
[0:10:15.189497] Projection generation completed.

After:
[0:04:49.822475] Projection generation completed.
```

I'm not sure the approach is perfect here (having to call `_populateTypeDefs()` in each place before it tries to use them), it could be wrapped up in another class, populated in the constructor, in some `lazy` initializers on the fields or something else. I can tweak if you have suggestions (otherwise, feel free to just use the idea and implement another way :-))