### PR TITLE
Fix `simpleArrayType`

### DIFF
--- a/lib/src/parameter.dart
+++ b/lib/src/parameter.dart
@@ -9,6 +9,7 @@ import 'package:ffi/ffi.dart';
 import 'package:win32/win32.dart';
 
 import 'com/enums.dart';
+import 'enums.dart';
 import 'method.dart';
 import 'mixins/customattributes_mixin.dart';
 import 'scope.dart';
@@ -71,6 +72,17 @@ class Parameter extends TokenObject with CustomAttributesMixin {
   factory Parameter.fromTypeIdentifier(
           Scope scope, int methodToken, TypeIdentifier runtimeType) =>
       Parameter(scope, 0, methodToken, 0, 0, runtimeType, '', Uint8List(0));
+
+  /// Creates a void parameter object.
+  factory Parameter.fromVoid(Scope scope, int methodToken) => Parameter(
+      scope,
+      0,
+      methodToken,
+      0,
+      0,
+      TypeIdentifier(BaseType.voidType),
+      '',
+      Uint8List(0));
 
   @override
   String toString() => name;

--- a/test/winrt_test.dart
+++ b/test/winrt_test.dart
@@ -581,7 +581,15 @@ void main() {
 
     final method = winTypeDef.findMethod('GetUInt8Array')!;
     expect(method.isProperty, isFalse);
-    expect(method.parameters.length, equals(1));
+    expect(method.parameters.length, equals(2));
+
+    final valueSizeParam = method.parameters.first;
+    expect(valueSizeParam.name, equals('__valueSize'));
+    expect(valueSizeParam.typeIdentifier.baseType,
+        equals(BaseType.pointerTypeModifier));
+    expect(valueSizeParam.typeIdentifier.typeArg, isNotNull);
+    expect(valueSizeParam.typeIdentifier.typeArg?.baseType,
+        equals(BaseType.uint32Type));
 
     final valueParam = method.parameters.last;
     expect(valueParam.name, equals('value'));

--- a/test/winrt_test.dart
+++ b/test/winrt_test.dart
@@ -603,6 +603,27 @@ void main() {
         equals(BaseType.uint8Type));
   });
 
+  test('IPropertyValueStatics array type', () {
+    final winTypeDef = MetadataStore.getMetadataForType(
+        'Windows.Foundation.IPropertyValueStatics')!;
+
+    final method = winTypeDef.findMethod('CreateUInt8Array')!;
+    expect(method.isProperty, isFalse);
+    expect(method.parameters.length, equals(2));
+
+    final valueSizeParam = method.parameters.first;
+    expect(valueSizeParam.name, equals('__valueSize'));
+    expect(valueSizeParam.typeIdentifier.baseType, equals(BaseType.uint32Type));
+
+    final valueParam = method.parameters.last;
+    expect(valueParam.name, equals('value'));
+    expect(
+        valueParam.typeIdentifier.baseType, equals(BaseType.simpleArrayType));
+    expect(valueParam.typeIdentifier.typeArg, isNotNull);
+    expect(valueParam.typeIdentifier.typeArg!.baseType,
+        equals(BaseType.uint8Type));
+  });
+
   test('Can find generic types', () {
     final winTypeDef = MetadataStore.getMetadataForType(
         'Windows.Foundation.IAsyncOperation`1');


### PR DESCRIPTION
I believe `simpleArrayType` parameters need an array size parameter (`__valueSize`) in order to work. This is also mentioned in [here](https://docs.microsoft.com/en-us/uwp/winrt-cref/winrt-type-system#array-parameters).

I've used the code that got removed in #57 and modified it a little to make it work for `simpleArrayType` (e.g. IPropertyValueStatics' `CreateUInt8Array()`) and also for reference types that wrap `simpleArrayType` (e.g. IPropertyValue's `GetUInt8Array()`). 

With this change, `CreateUInt8Array` method would be generated as:
```dart
  Pointer<COMObject> CreateUInt8Array(int valueSize, Pointer<Uint8> value) {
    final retValuePtr = calloc<COMObject>();

    final hr = ptr.ref.vtable
            .elementAt(26)
            .cast<
                Pointer<
                    NativeFunction<
                        HRESULT Function(Pointer, Uint32 valueSize,
                            Pointer<Uint8> value, Pointer<COMObject>)>>>()
            .value
            .asFunction<
                int Function(Pointer, int valueSize, Pointer<Uint8> value,
                    Pointer<COMObject>)>()(
        ptr.ref.lpVtbl, valueSize, value, retValuePtr);

    if (FAILED(hr)) throw WindowsException(hr);

    return retValuePtr;
  }
```

While `GetUInt8Array` method would be generated as:
```dart
  void GetUInt8Array(Pointer<Uint32> valueSize, Pointer<Uint8> value) {
    final hr = ptr.ref.vtable
        .elementAt(26)
        .cast<
            Pointer<
                NativeFunction<
                    HRESULT Function(Pointer, Pointer<Uint32> valueSize,
                        Pointer<Uint8> value)>>>()
        .value
        .asFunction<
            int Function(Pointer, Pointer<Uint32> valueSize,
                Pointer<Uint8> value)>()(ptr.ref.lpVtbl, valueSize, value);

    if (FAILED(hr)) throw WindowsException(hr);
  }
```

The only difference between them is the projection of the `valueSize` parameter. For reference types that wrap simpleArrayType (e.g. `GetUInt8Array`), the native type of the valueSize parameter must be `Pointer<Uint32>` to obtain the size of the `value`, and `Uint32` for simpleArrayType (e.g. `CreateUInt8Array`) to specify the size of the `value`.