### PR TITLE
Apply simpleArrayType's length once

### DIFF
--- a/lib/src/method.dart
+++ b/lib/src/method.dart
@@ -292,15 +292,13 @@ class Method extends TokenObject
       blobPtr += runtimeType.offsetLength;
 
       if (runtimeType.typeIdentifier.baseType == BaseType.simpleArrayType) {
-        blobPtr += _parseSimpleArray(runtimeType, paramsIndex) + 2;
+        _parseSimpleArray(runtimeType, paramsIndex);
         paramsIndex++; // we've added two parameters here
       } else if (runtimeType.typeIdentifier.baseType ==
               BaseType.referenceTypeModifier &&
           runtimeType.typeIdentifier.typeArg?.baseType ==
               BaseType.simpleArrayType) {
-        blobPtr +=
-            _parseSimpleArray(runtimeType, paramsIndex, isReferenceType: true) +
-                2;
+        _parseSimpleArray(runtimeType, paramsIndex, isReferenceType: true);
         paramsIndex++; // we've added two parameters here
       } else {
         parameters[paramsIndex].typeIdentifier = runtimeType.typeIdentifier;
@@ -327,7 +325,7 @@ class Method extends TokenObject
   // Various projections do smart things to mask this into a single array
   // value. We're not that clever yet, so we project it in its raw state, which
   // means a little work here to ensure that it comes out right.
-  int _parseSimpleArray(TypeTuple typeTuple, int paramsIndex,
+  void _parseSimpleArray(TypeTuple typeTuple, int paramsIndex,
       {bool isReferenceType = false}) {
     parameters[paramsIndex].name = '__valueSize';
 
@@ -345,7 +343,5 @@ class Method extends TokenObject
     parameters.insert(paramsIndex + 1, Parameter.fromVoid(scope, token));
     parameters[paramsIndex + 1].name = 'value';
     parameters[paramsIndex + 1].typeIdentifier = typeTuple.typeIdentifier;
-
-    return typeTuple.offsetLength;
   }
 }

--- a/test/method_test.dart
+++ b/test/method_test.dart
@@ -81,4 +81,14 @@ void main() {
     check(method.pinvokeMap.throwOnUnmappableCharConvention)
         .equals(ThrowOnUnmappableChar.useAssem);
   });
+
+  test('Methods with arrays have correct parameters', () {
+    final typeDef = MetadataStore.getMetadataForType(
+        'Windows.Foundation.Diagnostics.ILoggingFields');
+    final method = typeDef!.findMethod('AddInt32Array')!;
+    check(method.parameters.length).equals(5);
+    check(method.parameters.last.name).equals('tags');
+    check(method.parameters.last.typeIdentifier.baseType)
+        .equals(BaseType.int32Type);
+  });
 }


### PR DESCRIPTION
Previously this would advance the blob pointer twice, resulting in an error thrown when reading following parameters.