### PR TITLE
Exclude methods with missing references when enumerating the methods of a TypeDef

### DIFF
--- a/lib/src/typedef.dart
+++ b/lib/src/typedef.dart
@@ -509,7 +509,19 @@ class TypeDef extends TokenObject
       while (hr == S_OK) {
         final methodToken = rgMethods.value;
 
-        methods.add(Method.fromToken(scope, methodToken));
+        try {
+          methods.add(Method.fromToken(scope, methodToken));
+        } on WindowsException catch (e) {
+          if (e.hr.toUnsigned(32) == RO_E_METADATA_NAME_NOT_FOUND) {
+            // If the method cannot be parsed due to missing references, rather
+            // than abruptly exiting, proceed to the next one
+            print('Could not parse the method with token $methodToken from '
+                '$name:\n $e');
+          } else {
+            rethrow;
+          }
+        }
+
         hr = reader.enumMethods(phEnum, token, rgMethods, 1, pcTokens);
       }
       reader.closeEnum(phEnum.value);

--- a/test/win32_test.dart
+++ b/test/win32_test.dart
@@ -21,9 +21,17 @@ void main() {
     check(scope.userStrings.length).equals(0);
   });
 
-  test('Can successfully load a typedef from the Win32 metadata', () {
+  test('Can successfully load a typedef from the Win32 metadata 1', () {
     final scope = MetadataStore.getWin32Scope();
     final typedef = scope.findTypeDef('Windows.Win32.Graphics.Gdi.Apis');
+    check(typedef).isNotNull();
+    check(typedef!.methods).isNotEmpty();
+  });
+
+  test('Can successfully load a typedef from the Win32 metadata 2', () {
+    final scope = MetadataStore.getWin32Scope();
+    final typedef =
+        scope.findTypeDef('Windows.Win32.System.WinRT.Metadata.Apis');
     check(typedef).isNotNull();
     check(typedef!.methods).isNotEmpty();
   });


### PR DESCRIPTION
Fixes dart-windows/win32#721

@timsneath It's this annoying exception again, which we've encountered before at  https://github.com/dart-windows/win32/issues/697#issuecomment-1541500049.

In that pull request, we disabled the failed test to mitigate the issue. However, it seems that we missed a code snippet in [tool\win32gen\bin\generate.dart](https://github.com/dart-windows/win32/blob/49452bfe11bd0e8277e9460e0d0c504427abd996/tool/win32gen/bin/generate.dart#L116-L120), which is causing the exception described in dart-windows/win32#721.

To address this issue, this PR catches the exceptions that occur when parsing methods due to missing references, and it also prints some information about the problematic methods:
![image](https://github.com/dart-windows/winmd/assets/45524029/1ab3f9d2-c827-47b6-a943-dceca9448b2e)

What are your thoughts on this approach?